### PR TITLE
Adding initial GH actions support for UTs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,29 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build_and_test:
+    name: "Check if BlazingMQ Java SDK can build and pass unit tests with JDK ${{ matrix.Java }}"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ '8', '11', '17' ]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        distribution: 'zulu'
+        java-version: ${{ matrix.java }}
+    - name: Build and Test with Maven
+      run:  mvn -B -q -Dspotbugs.skip=true -Dspotless.check.skip=true test


### PR DESCRIPTION
Initial support for GH actions for running UTs in Java SDK.  SDK is built and UTs are run with JDK 8, 11 and 17.  I am sure that the pipeline can be cleaned up and enhanced, but that can be done subsequently.

Sample run can be found [here](https://github.com/quarter-note/blazingmq-sdk-java/actions/runs/5675977681/job/15382012358).

@sgalichkin @678098 @mlongob FYI