### PR TITLE
Fix: use existing domain in tutorials

### DIFF
--- a/bmq-examples/src/main/java/com/bloomberg/bmq/examples/InteractiveConsumer.java
+++ b/bmq-examples/src/main/java/com/bloomberg/bmq/examples/InteractiveConsumer.java
@@ -83,7 +83,7 @@ public class InteractiveConsumer
         implements AutoCloseable, SessionEventHandler, QueueEventHandler, PushMessageHandler {
 
     static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-    static final Uri uri = new Uri("bmq://bmq.tutorial.hello/test-queue");
+    static final Uri uri = new Uri("bmq://bmq.test.mem.priority/test-queue");
 
     AbstractSession session;
     Queue queue;

--- a/bmq-examples/src/main/java/com/bloomberg/bmq/examples/InteractiveProducer.java
+++ b/bmq-examples/src/main/java/com/bloomberg/bmq/examples/InteractiveProducer.java
@@ -91,7 +91,7 @@ public class InteractiveProducer
         implements AutoCloseable, SessionEventHandler, QueueEventHandler, AckMessageHandler {
 
     static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-    static final Uri uri = new Uri("bmq://bmq.tutorial.hello/test-queue");
+    static final Uri uri = new Uri("bmq://bmq.test.mem.priority/test-queue");
 
     AbstractSession session;
     Queue queue;

--- a/bmq-examples/src/main/java/com/bloomberg/bmq/examples/SimpleConsumer.java
+++ b/bmq-examples/src/main/java/com/bloomberg/bmq/examples/SimpleConsumer.java
@@ -87,7 +87,7 @@ public class SimpleConsumer {
     }
 
     public static void main(String[] args) throws InterruptedException {
-        final Uri uri = new Uri("bmq://bmq.tutorial.hello/queue-simple");
+        final Uri uri = new Uri("bmq://bmq.test.mem.priority/queue-simple");
         final Duration TIMEOUT = Duration.ofSeconds(15); // 15 seconds
         final int MSG_TIMEOUT = 60; // 60 seconds
 

--- a/bmq-examples/src/main/java/com/bloomberg/bmq/examples/SimpleProducer.java
+++ b/bmq-examples/src/main/java/com/bloomberg/bmq/examples/SimpleProducer.java
@@ -65,7 +65,7 @@ public class SimpleProducer {
     }
 
     public static void main(String[] args) {
-        final Uri uri = new Uri("bmq://bmq.tutorial.hello/queue-simple");
+        final Uri uri = new Uri("bmq://bmq.test.mem.priority/queue-simple");
         final Duration TIMEOUT = Duration.ofSeconds(15); // 15 seconds
 
         String brokerUri = System.getenv("BMQ_BROKER_URI");


### PR DESCRIPTION
Similar to: https://github.com/bloomberg/blazingmq/pull/39/files

Some uris containing `bmq.tutorials.hello` in unit tests cannot be changed easily, because these are being checked with resource files with binary content: [search bmq.tutorial.hello](https://github.com/search?q=repo%3Abloomberg%2Fblazingmq-sdk-java+bmq.tutorial.hello&type=code)