### PR TITLE
Fix: reduce frequent logging

### DIFF
--- a/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/PutPoster.java
+++ b/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/PutPoster.java
@@ -124,7 +124,7 @@ public final class PutPoster {
 
         int eventLength = putBuilder.eventLength();
         int msgCount = putBuilder.messageCount();
-        logger.info("Sending {} PUT messages...", msgCount);
+        logger.debug("Sending {} PUT messages...", msgCount);
 
         writeBuffer(putBuilder.build());
 
@@ -148,7 +148,7 @@ public final class PutPoster {
                 unacknowledgedPuts.put(p.correlationId(), p);
             }
         }
-        logger.info("Unacknowledged PUT messages {}", unacknowledgedPuts.size());
+        logger.debug("Unacknowledged PUT messages {}", unacknowledgedPuts.size());
     }
 
     public void registerAck(AckMessageImpl ackMsg) {

--- a/bmq-sdk/src/test/java/com/bloomberg/bmq/it/BrokerSessionStressIT.java
+++ b/bmq-sdk/src/test/java/com/bloomberg/bmq/it/BrokerSessionStressIT.java
@@ -128,7 +128,7 @@ public class BrokerSessionStressIT {
                                 String payload = createPayload(payloadSize, Integer.toString(i));
                                 PutMessageImpl msg =
                                         TestTools.preparePutMessage(payload, isOldStyleProperties);
-                                logger.info("Sending {}", msg);
+                                logger.debug("Sending {}", msg);
 
                                 putMessages.add(msg);
                                 payloads.add(
@@ -163,7 +163,7 @@ public class BrokerSessionStressIT {
                             String guid = pm.messageGUID().toString();
                             AckMessageImpl lastAck = ackMessages.peekLast();
 
-                            logger.info("Got PUSH with GUID: {}", guid);
+                            logger.debug("Got PUSH with GUID: {}", guid);
                             if (guid.endsWith("00000000000000000")) {
                                 logger.error("Got strange PUSH: {}", pm);
                                 logger.error("Previous PUSH: {}", pushMessages.peekLast());
@@ -184,9 +184,9 @@ public class BrokerSessionStressIT {
                             }
                         } else if (event instanceof AckMessageEvent) {
                             AckMessageImpl msg = ((AckMessageEvent) event).rawMessage();
-                            logger.info(
+                            logger.debug(
                                     "Got ACK [{}] with GUID: {}", msg.status(), msg.messageGUID());
-                            logger.info("Got ACK: {}", msg);
+                            logger.debug("Got ACK: {}", msg);
                             ackMessages.add(msg);
                         }
                         break;

--- a/bmq-sdk/src/test/java/com/bloomberg/bmq/it/SessionStressIT.java
+++ b/bmq-sdk/src/test/java/com/bloomberg/bmq/it/SessionStressIT.java
@@ -162,7 +162,7 @@ public class SessionStressIT {
                 String guid = pm.messageGUID().toString();
                 AckMessage lastAck = ackMessages.peekLast();
 
-                logger.info("Got PUSH with GUID: {}", guid);
+                logger.debug("Got PUSH with GUID: {}", guid);
 
                 // Send Confirm
                 if (GenericResult.SUCCESS == pm.confirm()) {
@@ -178,7 +178,7 @@ public class SessionStressIT {
                 }
             } else if (event instanceof AckMessage) {
                 AckMessage msg = (AckMessage) event;
-                logger.info("Got ACK [{}] with GUID: {}", msg.status(), msg.messageGUID());
+                logger.debug("Got ACK [{}] with GUID: {}", msg.status(), msg.messageGUID());
                 ackMessages.add(msg);
             }
             return state;
@@ -259,14 +259,14 @@ public class SessionStressIT {
         }
 
         void printStat() {
-            logger.error("Sent PUTs: {}", putMessages.size());
-            logger.error("Got ACKs : {}", ackMessages.size());
-            logger.error("Got PUSHs: {}", pushMessages.size());
+            logger.info("Sent PUTs: {}", putMessages.size());
+            logger.info("Got ACKs : {}", ackMessages.size());
+            logger.info("Got PUSHs: {}", pushMessages.size());
 
             if (pushMessages.size() > 0) {
-                logger.error("Last PUT : {}", putMessages.peekLast());
-                logger.error("Last ACK : {}", ackMessages.peekLast());
-                logger.error("Last PUSH: {}", pushMessages.peekLast());
+                logger.info("Last PUT : {}", putMessages.peekLast());
+                logger.info("Last ACK : {}", ackMessages.peekLast());
+                logger.info("Last PUSH: {}", pushMessages.peekLast());
             }
         }
 
@@ -280,7 +280,7 @@ public class SessionStressIT {
 
         void validateSingleMode() throws BMQException {
 
-            logger.error("Begin validation. Memory used: {}", TestTools.getUsedMemoryMB());
+            logger.info("Begin validation. Memory used: {}", TestTools.getUsedMemoryMB());
 
             final int NUM_MESSAGES = pushMessages.size();
 

--- a/bmq-sdk/src/test/java/com/bloomberg/bmq/it/SessionStressIT.java
+++ b/bmq-sdk/src/test/java/com/bloomberg/bmq/it/SessionStressIT.java
@@ -280,7 +280,7 @@ public class SessionStressIT {
 
         void validateSingleMode() throws BMQException {
 
-            logger.info("Begin validation. Memory used: {}", TestTools.getUsedMemoryMB());
+            logger.info("Begin validation. Memory used: {} MB", TestTools.getUsedMemoryMB());
 
             final int NUM_MESSAGES = pushMessages.size();
 


### PR DESCRIPTION
Logs from ITs: 124k lines, 26k lines is Broker build step => 98k lines for IT run

15.6k - INFO PutPoster:127 Sending
15.6k - INFO PutPoster:156 Unacknowledged PUT messages
3k - INFO BrokerSessionStressIT:166 Got PUSH with GUID
3k - INFO BrokerSessionStressIT:187 Got ACK
3k - INFO BrokerSessionStressIT:189 Got ACK
3k - INFO BrokerSessionStressIT:131 Sending

PutPoster change is the most critical here, because it's used in a normal non-IT flow for just every posted message.