### PR TITLE
Set atomic before enqueueing (DIS)CONNECTED event

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,4 +26,4 @@ jobs:
         distribution: 'zulu'
         java-version: ${{ matrix.java }}
     - name: Build and Test with Maven
-      run:  mvn -B -q -Dspotbugs.skip=true -Dspotless.check.skip=true test
+      run:  mvn -B -q -Dspotbugs.skip=true test

--- a/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/BrokerSession.java
+++ b/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/BrokerSession.java
@@ -368,12 +368,13 @@ public final class BrokerSession
                 (BrokerConnection.StartStatus status) -> {
                     logger.info("Start callback: {}", status);
                     onStartTimeoutFuture.cancel(false);
+                    isStarting.set(false);
                     switch (status) {
                         case SUCCESS:
-                            enqueueConnected();
-
                             // Enabled scheduled stats dumping
                             stats.enableDumping();
+
+                            enqueueConnected();
                             break;
                         case CANCELLED:
                             enqueueCanceled();
@@ -382,7 +383,6 @@ public final class BrokerSession
                             enqueueError();
                             break;
                     }
-                    isStarting.set(false);
                 });
     }
 
@@ -491,13 +491,14 @@ public final class BrokerSession
                             logger.debug("Broker connection stopped.");
 
                             onStopTimeoutFuture.cancel(false);
-                            enqueueDisconnected();
-                            isStopping.set(false);
 
                             // Disable scheduled stats dumping
                             stats.disableDumping();
                             // Print final statistics
                             stats.dumpFinal();
+
+                            isStopping.set(false);
+                            enqueueDisconnected();
                         },
                         scheduler);
 

--- a/bmq-sdk/src/test/java/com/bloomberg/bmq/impl/infr/net/NetResolverTest.java
+++ b/bmq-sdk/src/test/java/com/bloomberg/bmq/impl/infr/net/NetResolverTest.java
@@ -42,9 +42,7 @@ public class NetResolverTest {
         assertEquals(0, nr.numResolvedHosts());
         assertNull(uri);
 
-        String[] uris = {
-            "tcp://localhost:30114", "www.apache.org", "tcp://255.255.255.255:30114"
-        };
+        String[] uris = {"tcp://localhost:30114", "www.apache.org", "tcp://255.255.255.255:30114"};
 
         try {
             for (String u : uris) {


### PR DESCRIPTION
**Describe your changes**
Modify `BrokerSession::startAsync()` and `BrokerSession::stopAsync()` to set atomic before enqueueing (DIS)CONNECTED session event. Otherwise the the following scenario is possible:
1. Call startAsync/stopAsync
2. Get (DIS)CONNECTED event
3. Call startAsync/stopAsync again
4. Get (DIS)CONNECTION_IN_PROGRESS event while (DIS)CONNECTED is expected instead

**Testing performed**
Two simple unit-tests are provided
