### PR TITLE
Allow SessionOptions.Builder to copy existing options

### DIFF
--- a/bmq-sdk/src/main/java/com/bloomberg/bmq/SessionOptions.java
+++ b/bmq-sdk/src/main/java/com/bloomberg/bmq/SessionOptions.java
@@ -256,7 +256,18 @@ public final class SessionOptions {
      * @return Builder session options setter
      */
     public static Builder builder() {
-        return new Builder();
+        return builder(createDefault());
+    }
+
+    /**
+     * Returns a helper class object to set different session level options.
+     *
+     * @param options specifies options which initializes the builder
+     * @return Builder session options setter
+     */
+    public static Builder builder(SessionOptions options) {
+        Argument.expectNonNull(options, "options");
+        return new Builder(options);
     }
 
     /**
@@ -395,27 +406,7 @@ public final class SessionOptions {
             return new SessionOptions(this);
         }
 
-        private Builder() {
-            brokerUri = DEFAULT_URI;
-            startTimeout = DEFAULT_START_TIMEOUT;
-            stopTimeout = DEFAULT_STOP_TIMEOUT;
-            writeWaterMark = new WriteBufferWaterMark();
-            inboundWaterMark = new InboundEventBufferWaterMark();
-            statsDumpInterval = DEFAULT_STATS_DUMP_INTERVAL;
-            openQueueTimeout = QUEUE_OPERATION_TIMEOUT;
-            configureQueueTimeout = QUEUE_OPERATION_TIMEOUT;
-            closeQueueTimeout = QUEUE_OPERATION_TIMEOUT;
-            hostHealthMonitor = null;
-        }
-
-        /**
-         * Copies another 'SessionOptions' into this builder.
-         *
-         * @param options specifies options which is copied into the builder
-         * @return Builder this object
-         */
-        public Builder copyFrom(SessionOptions options) {
-
+        private Builder(SessionOptions options) {
             brokerUri = options.brokerUri;
             startTimeout = options.startTimeout;
             stopTimeout = options.stopTimeout;
@@ -426,8 +417,6 @@ public final class SessionOptions {
             configureQueueTimeout = options.configureQueueTimeout;
             closeQueueTimeout = options.closeQueueTimeout;
             hostHealthMonitor = options.hostHealthMonitor;
-
-            return this;
         }
 
         /**

--- a/bmq-sdk/src/main/java/com/bloomberg/bmq/SessionOptions.java
+++ b/bmq-sdk/src/main/java/com/bloomberg/bmq/SessionOptions.java
@@ -409,6 +409,28 @@ public final class SessionOptions {
         }
 
         /**
+         * Copies another 'SessionOptions' into this builder.
+         *
+         * @param options specifies options which is copied into the builder
+         * @return Builder this object
+         */
+        public Builder copyFrom(SessionOptions options) {
+
+            brokerUri = options.brokerUri;
+            startTimeout = options.startTimeout;
+            stopTimeout = options.stopTimeout;
+            writeWaterMark = options.writeWaterMark;
+            inboundWaterMark = options.inboundWaterMark;
+            statsDumpInterval = options.statsDumpInterval;
+            openQueueTimeout = options.openQueueTimeout;
+            configureQueueTimeout = options.configureQueueTimeout;
+            closeQueueTimeout = options.closeQueueTimeout;
+            hostHealthMonitor = options.hostHealthMonitor;
+
+            return this;
+        }
+
+        /**
          * Sets URI to connect with the broker.
          *
          * @param value URI to set

--- a/bmq-sdk/src/test/java/com/bloomberg/bmq/SessionOptionsTest.java
+++ b/bmq-sdk/src/test/java/com/bloomberg/bmq/SessionOptionsTest.java
@@ -146,7 +146,7 @@ public class SessionOptionsTest {
     }
 
     @Test
-    public void testCopyFrom() {
+    public void testBuilderWithOptions() {
         // GSON cannot serialize Duration type, so add simple adapter to convert Duration to string
         GsonBuilder gsonBuilder = new GsonBuilder();
         gsonBuilder.registerTypeAdapter(
@@ -161,9 +161,11 @@ public class SessionOptionsTest {
         Gson gson = gsonBuilder.create();
 
         SessionOptions defaulOptions = SessionOptions.createDefault();
+        assertEquals(gson.toJson(defaulOptions), gson.toJson(SessionOptions.builder().build()));
+
         assertEquals(
                 gson.toJson(defaulOptions),
-                gson.toJson(SessionOptions.builder().copyFrom(defaulOptions).build()));
+                gson.toJson(SessionOptions.builder(defaulOptions).build()));
 
         Duration startTimeout = Duration.ofSeconds(1);
         Duration stopTimeout = Duration.ofMinutes(1);
@@ -176,7 +178,6 @@ public class SessionOptionsTest {
 
         assertNotEquals(gson.toJson(defaulOptions), gson.toJson(newOptions));
         assertEquals(
-                gson.toJson(newOptions),
-                gson.toJson(SessionOptions.builder().copyFrom(newOptions).build()));
+                gson.toJson(newOptions), gson.toJson(SessionOptions.builder(newOptions).build()));
     }
 }

--- a/bmq-sdk/src/test/java/com/bloomberg/bmq/SessionOptionsTest.java
+++ b/bmq-sdk/src/test/java/com/bloomberg/bmq/SessionOptionsTest.java
@@ -16,10 +16,18 @@
 package com.bloomberg.bmq;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import java.lang.reflect.Type;
 import java.time.Duration;
 import org.junit.Test;
 
@@ -135,5 +143,40 @@ public class SessionOptionsTest {
         SessionOptions options = SessionOptions.builder().setHostHealthMonitor(monitor).build();
 
         assertEquals(monitor, options.hostHealthMonitor());
+    }
+
+    @Test
+    public void testCopyFrom() {
+        // GSON cannot serialize Duration type, so add simple adapter to convert Duration to string
+        GsonBuilder gsonBuilder = new GsonBuilder();
+        gsonBuilder.registerTypeAdapter(
+                Duration.class,
+                new JsonSerializer<Duration>() {
+                    @Override
+                    public JsonElement serialize(
+                            Duration src, Type typeOfSrc, JsonSerializationContext context) {
+                        return new JsonPrimitive(src.toString());
+                    }
+                });
+        Gson gson = gsonBuilder.create();
+
+        SessionOptions defaulOptions = SessionOptions.createDefault();
+        assertEquals(
+                gson.toJson(defaulOptions),
+                gson.toJson(SessionOptions.builder().copyFrom(defaulOptions).build()));
+
+        Duration startTimeout = Duration.ofSeconds(1);
+        Duration stopTimeout = Duration.ofMinutes(1);
+
+        SessionOptions newOptions =
+                SessionOptions.builder()
+                        .setStartTimeout(startTimeout)
+                        .setStopTimeout(stopTimeout)
+                        .build();
+
+        assertNotEquals(gson.toJson(defaulOptions), gson.toJson(newOptions));
+        assertEquals(
+                gson.toJson(newOptions),
+                gson.toJson(SessionOptions.builder().copyFrom(newOptions).build()));
     }
 }

--- a/bmq-sdk/src/test/java/com/bloomberg/bmq/impl/infr/net/NetResolverTest.java
+++ b/bmq-sdk/src/test/java/com/bloomberg/bmq/impl/infr/net/NetResolverTest.java
@@ -42,9 +42,7 @@ public class NetResolverTest {
         assertEquals(0, nr.numResolvedHosts());
         assertNull(uri);
 
-        String[] uris = {
-            "tcp://localhost:30114", "www.apache.org", "tcp://255.255.255.255:30114"
-        };
+        String[] uris = {"tcp://localhost:30114", "www.apache.org", "tcp://255.255.255.255:30114"};
 
         try {
             for (String u : uris) {


### PR DESCRIPTION
**Describe your changes**
When building `SessionOptions`, allow to copy values from existing `SessionOptions` object

**Testing performed**
Unit test to check new method

**Additional context**
Decided to not implement `equals`, `hashCode` and `toString()` for `SessionOptions` in this PR