### PR TITLE
Ignore ACKs with unknown correlation ID

### DIFF
--- a/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/BrokerSession.java
+++ b/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/BrokerSession.java
@@ -847,7 +847,7 @@ public final class BrokerSession
     private CompletableFuture<OpenQueueCode> createReopenFuture(QueueImpl queue) {
         assert isInSessionExecutor();
         QueueId queueId = queue.getFullQueueId();
-        logger.error("Queue id={} should be reopened", queueId);
+        logger.info("Queue id={} should be reopened", queueId);
         final CompletableFuture<OpenQueueCode> future = new CompletableFuture<>();
         QueueControlStrategy<OpenQueueCode> strategy =
                 strategyFactory.createReopenAsyncSequence(

--- a/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/PutPoster.java
+++ b/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/PutPoster.java
@@ -178,8 +178,14 @@ public final class PutPoster {
 
         CorrelationIdImpl ackId = ackMsg.correlationId();
         PutMessageImpl putMsg = unacknowledgedPuts.remove(ackId);
+
+        // In some cases broker may send an ACK message with UNKNOWN correlation Id.  Most likely
+        // this means we receive the ACK message which has been already processed.  Since there is
+        // no unacknowledged PUT message with such correlation Id,  we just log such ACK message and
+        // return
         if (putMsg == null) {
-            throw new IllegalStateException("Correlation ID not found " + ackId);
+            logger.warn("Got ACK message with unknown correlation Id: {}", ackMsg);
+            return;
         }
 
         ackMsg.setCorrelationId((CorrelationIdImpl) putMsg.correlationId());

--- a/bmq-sdk/src/test/java/com/bloomberg/bmq/impl/PutPosterTest.java
+++ b/bmq-sdk/src/test/java/com/bloomberg/bmq/impl/PutPosterTest.java
@@ -343,22 +343,6 @@ public class PutPosterTest {
                             0);
             poster.registerAck(ackMsg); // should be just logged and ignored
 
-            // Try to register valid ACK message without sending PUT
-            ackMsg =
-                    new AckMessageImpl(
-                            AckResult.UNKNOWN,
-                            CorrelationIdImpl.restoreId(1),
-                            MessageGUID.createEmptyGUID(),
-                            0);
-            try {
-                poster.registerAck(ackMsg);
-                fail(); // Should not get here
-            } catch (IllegalStateException e) {
-                assertEquals(
-                        "Correlation ID not found [ CorrelationId [ UniqueId : " + 1 + " ] ]",
-                        e.getMessage());
-            }
-
             // Post PUT message and then register ACK message
             Object userData = new Object();
             CorrelationIdImpl cId = CorrelationIdImpl.nextId(userData);
@@ -380,6 +364,15 @@ public class PutPosterTest {
 
             assertEquals(cId, ackMsg.correlationId());
             assertEquals(userData, ackMsg.correlationId().userData());
+
+            // Try to register the same ACK message again
+            ackMsg =
+                    new AckMessageImpl(
+                            AckResult.SUCCESS,
+                            CorrelationIdImpl.restoreId(cId.toInt()),
+                            ackMsg.messageGUID(),
+                            0);
+            poster.registerAck(ackMsg); // should be just logged and ignored
         }
     }
 }


### PR DESCRIPTION
**Describe your changes**
1. Ignore ACKs with unknown correlation ID, just log a warn record
Most likely that means we received already processed ACK message
2. When reopen a queue, lower log level (error -> info)

**Additional context**
Requested by another team