### PR TITLE
Eliminate array copies

### DIFF
--- a/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/BrokerSession.java
+++ b/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/BrokerSession.java
@@ -59,7 +59,9 @@ import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.nio.ByteBuffer;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -1219,10 +1221,12 @@ public final class BrokerSession
         return queueStateManager.findByQueueId(queueId);
     }
 
-    public void post(QueueHandle queueHandle, PutMessageImpl... msgs) throws BMQException {
+    public void post(QueueHandle queueHandle, Collection<PutMessageImpl> msgs) throws BMQException {
         Argument.expectNonNull(queueHandle, "queueHandle");
         Argument.expectNonNull(msgs, "msgs");
-        Argument.expectPositive(msgs.length, "message array length");
+        if (msgs.isEmpty()) {
+            return;
+        }
 
         // Queue state guard
         QueueState state = queueHandle.getState();
@@ -1247,6 +1251,14 @@ public final class BrokerSession
 
             stats.queuesStats().onPutMessage(queueId, appDataSize, ratio);
         }
+    }
+
+    public void post(QueueHandle queueHandle, PutMessageImpl msg) throws BMQException {
+        post(queueHandle, Collections.singletonList(msg));
+    }
+
+    public void post(QueueHandle queueHandle, PutMessageImpl... msgs) throws BMQException {
+        post(queueHandle, Arrays.asList(msgs));
     }
 
     public GenericResult confirm(QueueHandle queueHandle, PushMessageImpl... messages) {

--- a/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/PutPoster.java
+++ b/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/PutPoster.java
@@ -33,7 +33,9 @@ import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -68,9 +70,9 @@ public final class PutPoster {
         maxEventSize = Argument.expectNotGreater(val, EventHeader.MAX_SIZE_SOFT, "max event size");
     }
 
-    public void pack(PutMessageImpl... msgs) {
+    public void pack(Collection<PutMessageImpl> msgs) {
         Argument.expectNonNull(msgs, "msgs");
-        Argument.expectPositive(msgs.length, "message array length");
+        Argument.expectPositive(msgs.size(), "message array length");
         for (PutMessageImpl m : msgs) {
             Argument.expectNonNull(m, "put message");
 
@@ -87,9 +89,17 @@ public final class PutPoster {
         }
     }
 
-    public void post(PutMessageImpl... msgs) {
+    public void post(Collection<PutMessageImpl> msgs) {
         pack(msgs);
         flush();
+    }
+
+    public void post(PutMessageImpl msg) {
+        post(Collections.singletonList(msg));
+    }
+
+    public void post(PutMessageImpl... msgs) {
+        post(Arrays.asList(msgs));
     }
 
     private void sendEvent() {

--- a/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/QueueImpl.java
+++ b/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/QueueImpl.java
@@ -265,9 +265,7 @@ public class QueueImpl implements QueueHandle {
     }
 
     public void pack(PutMessageImpl message) throws BMQException {
-        synchronized (lock) {
-            putMessages.get().add(message);
-        }
+        putMessages.get().add(message);
     }
 
     public void flush() throws BMQException {

--- a/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/infr/proto/AckMessageImpl.java
+++ b/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/infr/proto/AckMessageImpl.java
@@ -154,9 +154,7 @@ public class AckMessageImpl implements Streamable {
 
     public void streamOut(ByteBufferOutputStream bbos) throws IOException {
         bbos.writeInt(statusAndCorrelationId);
-        for (int i = 0; i < MessageGUID.SIZE_BINARY; i++) {
-            bbos.writeByte(messageGUID[i]);
-        }
+        bbos.write(messageGUID);
         bbos.writeInt(queueId);
     }
 

--- a/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/infr/proto/EventBuilder.java
+++ b/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/infr/proto/EventBuilder.java
@@ -46,7 +46,7 @@ public abstract class EventBuilder {
         }
 
         int payloadLen = bbos.size();
-        ByteBuffer[] payload = bbos.reset();
+        ByteBuffer[] payload = bbos.peek();
 
         eventHeader.setLength(EventHeader.HEADER_SIZE + payloadLen);
 
@@ -58,7 +58,7 @@ public abstract class EventBuilder {
             throw new IllegalStateException(ex);
         }
 
-        ByteBuffer[] headerBuffers = headerStream.reset();
+        ByteBuffer[] headerBuffers = headerStream.peek();
         int numBuffers = headerBuffers.length + payload.length;
 
         ByteBuffer[] outputBuffers = new ByteBuffer[numBuffers];

--- a/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/infr/proto/MessagePropertiesImpl.java
+++ b/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/infr/proto/MessagePropertiesImpl.java
@@ -396,7 +396,7 @@ public class MessagePropertiesImpl implements MessageProperties {
     }
 
     // TODO: remove boolean after 2nd rollout of "new style" brokers
-    private void streamOut(DataOutput output, boolean isOldStyleProperties) throws IOException {
+    void streamOut(DataOutput output, boolean isOldStyleProperties) throws IOException {
         final int numProps = propertyMap.size();
         if (numProps == 0) {
             logger.info("No message properties to stream out");

--- a/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/infr/proto/PutMessageImpl.java
+++ b/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/infr/proto/PutMessageImpl.java
@@ -24,7 +24,6 @@ import com.bloomberg.bmq.impl.infr.io.ByteBufferOutputStream;
 import com.bloomberg.bmq.impl.infr.proto.intf.Streamable;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
-import java.nio.ByteBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -115,10 +114,7 @@ public class PutMessageImpl implements Streamable {
     }
 
     public void calculateAndSetCrc32c() throws IOException {
-        // Calculate CRC32c
-        ByteBuffer[] bb = appData.applicationData();
-        final long CRC32C = Crc32c.calculate(bb);
-        header.setCrc32c(CRC32C);
+        header.setCrc32c(appData.calculateCrc32c());
     }
 
     public long crc32c() {

--- a/bmq-sdk/src/test/java/com/bloomberg/bmq/impl/PutPosterTest.java
+++ b/bmq-sdk/src/test/java/com/bloomberg/bmq/impl/PutPosterTest.java
@@ -43,6 +43,7 @@ import com.bloomberg.bmq.impl.intf.BrokerConnection;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -92,7 +93,7 @@ public class PutPosterTest {
 
         // NULL array
         try {
-            PutMessageImpl[] m = null;
+            List<PutMessageImpl> m = null;
             poster.post(m);
             fail(); // Should not get here
         } catch (IllegalArgumentException e) {
@@ -196,7 +197,7 @@ public class PutPosterTest {
             compressedMsg.appData().setProperties(props);
             compressedMsg.setCompressionType(CompressionAlgorithmType.E_ZLIB);
 
-            poster.post(bigMsg1, smallMsg1, bigMsg2, smallMsg2, compressedMsg);
+            poster.post(Arrays.asList(bigMsg1, smallMsg1, bigMsg2, smallMsg2, compressedMsg));
 
             assertEquals(isOldStyleProperties, bigMsg1.appData().isOldStyleProperties());
             assertEquals(isOldStyleProperties, smallMsg1.appData().isOldStyleProperties());

--- a/bmq-sdk/src/test/java/com/bloomberg/bmq/impl/infr/proto/AckEventImplBuilderTest.java
+++ b/bmq-sdk/src/test/java/com/bloomberg/bmq/impl/infr/proto/AckEventImplBuilderTest.java
@@ -74,8 +74,7 @@ public class AckEventImplBuilderTest {
             builder.packMessage(m);
         }
 
-        ByteBuffer[] message;
-        message = builder.build();
+        ByteBuffer[] message = builder.build();
 
         TestHelpers.compareWithFileContent(message, MessagesTestSamples.ACK_MSG);
     }


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #30 

**Describe your changes**
1. BrokerSession passes Collection<PutMessageImpl> instead of PutMessageImpl[] to avoid making copies.
2. ApplicationData calculates crc32c on the fly to avoid having to make an expensive copy of the whole payload.
3. ByteBufferOutputStream:
   - add peek() call to make an independent view of the underlying data.
   - don't copy and repack ByteBuffer's written to the ByteBufferOutputStream.
4. NettyTcpConnection still makes a copy of data read, but let netty make the copy instead of us.

**Testing performed**
Unit and integration tests have been updated to reflect the changes.

**Additional context**
As discussed with @sgalichkin 
