### PR TITLE
Fix: inbound watermark integration test

### DIFF
--- a/bmq-sdk/src/test/java/com/bloomberg/bmq/it/BrokerSessionIT.java
+++ b/bmq-sdk/src/test/java/com/bloomberg/bmq/it/BrokerSessionIT.java
@@ -185,7 +185,10 @@ public class BrokerSessionIT {
             QueueHandle queue) {
         assertNotNull(event);
         assertTrue(
-                "Expected 'QueueControlEvent', received '" + event.getClass().getName() + "'",
+                "Expected 'QueueControlEvent', received '"
+                        + event.getClass().getName()
+                        + "': "
+                        + event,
                 event instanceof QueueControlEvent);
 
         QueueControlEvent queueControlEvent = (QueueControlEvent) event;
@@ -197,7 +200,10 @@ public class BrokerSessionIT {
     private static void verifyBrokerSessionEvent(Event event, BrokerSessionEvent.Type eventType) {
         assertNotNull(event);
         assertTrue(
-                "Expected 'BrokerSessionEvent', received '" + event.getClass().getName() + "'",
+                "Expected 'BrokerSessionEvent', received '"
+                        + event.getClass().getName()
+                        + "': "
+                        + event,
                 event instanceof BrokerSessionEvent);
 
         BrokerSessionEvent brokerSessionEvent = (BrokerSessionEvent) event;

--- a/bmq-sdk/src/test/java/com/bloomberg/bmq/it/BrokerSessionIT.java
+++ b/bmq-sdk/src/test/java/com/bloomberg/bmq/it/BrokerSessionIT.java
@@ -5574,6 +5574,8 @@ public class BrokerSessionIT {
                         queue.openAsync(QueueOptions.createDefault(), SHORT_TIMEOUT)
                                 .get(SHORT_TIMEOUT));
                 queues[i] = queue;
+
+                TestTools.sleepForMilliSeconds(100);
             }
 
             // Here we expect one NOT_CONNECTED event which has been already

--- a/bmq-sdk/src/test/java/com/bloomberg/bmq/it/BrokerSessionIT.java
+++ b/bmq-sdk/src/test/java/com/bloomberg/bmq/it/BrokerSessionIT.java
@@ -5575,6 +5575,14 @@ public class BrokerSessionIT {
                                 .get(SHORT_TIMEOUT));
                 queues[i] = queue;
 
+                // We need to wait for a bit, so the `queueControlEventHandler` has time to poll
+                // the very first event from `InboundEventBuffer`. If we don't do it, there is a
+                // chance that HWM `BrokerSessionEvent` will be generated early and placed in
+                // the head of the buffer, resulting in this test's failure.
+                // We also need to wait for the second time on the third queue open, so the other
+                // thread has time to enqueue HWM `BrokerSessionEvent` to `InboundEventBuffer`.
+                // So this sleep is a workaround for a race condition existing here by test's
+                // design.
                 TestTools.sleepForMilliSeconds(100);
             }
 


### PR DESCRIPTION
The test was designed with assumption that the very first `QueueControlEvent` will be polled to `QueueControlEventHandler` **before** the `BrokerSessionEvent` with HWM will be generated. But this leads to a race condition, because HWM event is explicitly placed in the head of `InboundEventBuffer` and this causes events reordering in the buffer. Here:
https://github.com/bloomberg/blazingmq-sdk-java/blob/36a46c4db1d5a840247e5d7f8f4b83bbb9e23701/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/InboundEventBuffer.java#L111

By placing sleep after `QueueOpen` request, I make sure that `QueueControlEventHandler` has enough time to poll the very first event. It's not a beautiful solution, but the test design limits me with possible ways to fix it. Trying to fix it in a more beautiful way might require re-writing the test entirely.