### PR TITLE
Fix: return optional args to flattened .pom for ossrh

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,9 @@ limitations under the License. -->
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>flatten-maven-plugin</artifactId>
           <version>1.4.0</version>
+          <configuration>
+            <flattenMode>ossrh</flattenMode>
+          </configuration>
           <executions>
             <!-- enable flattening -->
             <execution>


### PR DESCRIPTION
https://www.mojohaus.org/flatten-maven-plugin/flatten-mojo.html#flattenMode