### PR TITLE
docs: remove horizontal rules, BlazingMQ consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ feature and/or API parity with the BlazingMQ C++ client library.
 - [Code of Conduct](#code-of-conduct)
 - [Security Vulnerability Reporting](#security-vulnerability-reporting)
 
----
 
 ## Using
 
@@ -137,36 +136,32 @@ $ JAVA_HOME=${PATH_TO_JDK11} mvn clean compile
   $ mvn -q -Dspotbugs.skip=true -Dspotless.check.skip=true -Dtest=OpenQueueTest#testReset test
   ```
 
----
 
 ## Contributions
 
 We welcome your contributions to help us improve and extend this project!
 
 We welcome issue reports [here](../../issues); be sure to choose the proper
-issue template for your issue, so that we can be sure you're providing the
-necessary information.
+issue template for your issue, so that we can be sure you're providing us with
+the necessary information.
 
-Before sending a [Pull Request](../../pulls), please make sure you read our
-[Contribution
-Guidelines](https://github.com/bloomberg/.github/blob/master/CONTRIBUTING.md).
+Before sending a [Pull Request](../../pulls), please make sure you have read
+our [Contribution
+Guidelines](https://github.com/bloomberg/.github/blob/main/CONTRIBUTING.md).
 
----
 
 ## License
 
-Please read the [LICENSE](LICENSE) file.
+The BlazingMQ Java SDK is Apache 2.0 licensed, as found in the [LICENSE](LICENSE) file.
 
----
 
 ## Code of Conduct
 
 This project has adopted a [Code of
-Conduct](https://github.com/bloomberg/.github/blob/master/CODE_OF_CONDUCT.md).
+Conduct](https://github.com/bloomberg/.github/blob/main/CODE_OF_CONDUCT.md).
 If you have any concerns about the Code, or behavior which you have experienced
 in the project, please contact us at opensource@bloomberg.net.
 
----
 
 ## Security Vulnerability Reporting
 
@@ -177,5 +172,3 @@ the suspected issue and any methods you've found to reproduce it.
 Please do NOT open an issue in the GitHub repository, as we'd prefer to keep
 vulnerability reports private until we've had an opportunity to review and
 address them.
-
----


### PR DESCRIPTION
This cleans up the formatting of the horizontal header rules which clutter up the sections. Also, makes the BlazingMQ Java SDK README format consistent with similar docs.