### PR TITLE
Split broker logs for different Java versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -94,6 +94,6 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v3
       with:
-        name: broker_logs
+        name: broker_logs_${{ matrix.java }}
         path: /tmp/bmq-broker/broker_logs.tar.gz
         retention-days: 5


### PR DESCRIPTION

**Describe your changes**
Logs for all Java versions from testing matrix: [ '8', '11', '17' ] were saved as an archive file with the same overwriting each other. This fix saves logs for each Java version into a separate file.

**Testing performed**
All pipelines passed

**Additional context**

![Screenshot 2024-10-24 131245](https://github.com/user-attachments/assets/2a9c9ebe-8042-4e21-91e6-686f1799e8a0)

![Screenshot 2024-10-24 131252](https://github.com/user-attachments/assets/56703f40-6328-4aa1-abb5-cdfa36313e3c)



