### PR TITLE
CI: Use newer version of `actions/upload-artifact`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -92,7 +92,7 @@ jobs:
 
     - name: Upload broker logs as artifacts
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: broker_logs_${{ matrix.java }}
         path: /tmp/bmq-broker/broker_logs.tar.gz


### PR DESCRIPTION
CI is failing because of the deprecated version of `actions/upload-artifact`.  According to the documentation linked in https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/, our usage of this action is safe to just bump the version number from `v3` to `v4`.