### PR TITLE
CI: fix cache, build once a day

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  get_dependencies:
+    name: "Dependencies"
+    uses: ./.github/workflows/dependencies.yaml
+
   build_and_test:
     name: "Build & UTs: JDK ${{ matrix.Java }}"
     runs-on: ubuntu-latest
@@ -30,52 +34,28 @@ jobs:
 
   integration_test:
     name: "ITs: JDK ${{ matrix.Java }}"
+    needs: get_dependencies
     runs-on: ubuntu-latest
     strategy:
       matrix:
         java: [ '8', '11', '17' ]
     steps:
     - uses: actions/checkout@v3
+
     - uses: actions/setup-java@v3
       with:
         distribution: 'zulu'
         java-version: ${{ matrix.java }}
-    - name: Checkout BlazingMQ
-      run:  git clone https://github.com/bloomberg/blazingmq
-
-    - name: Get latest BlazingMQ commit SHA
-      id: get-sha
-      working-directory: blazingmq
-      run: echo "blazingmq_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
     - name: Get cached BlazingMQ docker image
       id: cache-restore
       uses: actions/cache/restore@v4
       with:
         path: blazingmq_image.tar.gz
-        key: ${{ steps.get-sha.outputs.blazingmq_sha }}
-
-    # Pull docker image instead
-    - name: Build base BlazingMQ docker image
-      if: steps.cache-restore.outputs.cache-hit != 'true'
-      working-directory: blazingmq
-      run: docker compose -f docker/single-node/docker-compose.yaml build
+        key: ${{ needs.get_dependencies.outputs.cache_key }}
 
     - name: Load base BlazingMQ docker image from cache
-      if: steps.cache-restore.outputs.cache-hit == 'true'
       run: docker load < blazingmq_image.tar.gz
-
-    - name: Save built BlazingMQ docker image
-      if: steps.cache-restore.outputs.cache-hit != 'true'
-      run: docker save bmqbrkr:latest | gzip > blazingmq_image.tar.gz
-
-    - name: Cache built BlazingMQ docker image
-      id: cache-save
-      if: steps.cache-restore.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
-      with:
-        path: blazingmq_image.tar.gz
-        key: ${{ steps.get-sha.outputs.blazingmq_sha }}
 
     - name: Build IT image
       working-directory: bmq-sdk/src/test/docker

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -1,0 +1,58 @@
+name: Dependencies
+
+on:
+  workflow_call:
+    outputs:
+      cache_key:
+        description: "GH Actions Cache key associated with the built dependencies"
+        value: ${{ jobs.build_dependencies.outputs.cache_key }}
+  schedule:
+    # Rebuild dependencies cache from the "main" branch at the beginning of a new day,
+    # so it is accessible from other branches' PRs
+    - cron: "10 0 * * *"
+
+concurrency:
+  group: global
+  cancel-in-progress: false
+
+jobs:
+  build_dependencies:
+    name: Build broker image
+    runs-on: ubuntu-latest
+    outputs:
+      cache_key: ${{ steps.get-cache-key.outputs.cache_key }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Checkout BlazingMQ
+        run:  git clone https://github.com/bloomberg/blazingmq
+
+      - name: Generate dependencies cache key
+        id: get-cache-key
+        run: |
+          echo "cache_key=deps-`date +%y-%m-%d`" >> $GITHUB_OUTPUT
+
+      - name: Cache lookup
+        uses: actions/cache/restore@v4
+        id: cache-lookup
+        with:
+          path: blazingmq_image.tar.gz
+          key: ${{ steps.get-cache-key.outputs.cache_key }}
+          lookup-only: true
+
+      # TODO: pull docker image from the registry once we support it
+      - name: Build base BlazingMQ docker image
+        if: steps.cache-lookup.outputs.cache-hit != 'true'
+        working-directory: blazingmq
+        run: docker compose -f docker/single-node/docker-compose.yaml build
+
+      - name: Save built BlazingMQ docker image
+        if: steps.cache-lookup.outputs.cache-hit != 'true'
+        run: docker save bmqbrkr:latest | gzip > blazingmq_image.tar.gz
+
+      - name: Save cache
+        if: steps.cache-lookup.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: blazingmq_image.tar.gz
+          key: ${{ steps.get-cache-key.outputs.cache_key }}


### PR DESCRIPTION
- Build base BlazingMQ docker image nightly and cache it
- Do not spend resources building the same image in parallel many times