### PR TITLE
IT: fix flaky BrokerSessionIT

### DIFF
--- a/bmq-sdk/src/test/java/com/bloomberg/bmq/it/BrokerSessionIT.java
+++ b/bmq-sdk/src/test/java/com/bloomberg/bmq/it/BrokerSessionIT.java
@@ -86,6 +86,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.BooleanSupplier;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -97,6 +98,18 @@ public class BrokerSessionIT {
     static final int NO_CLIENT_REQUEST_TIMEOUT = 1; // sec
 
     static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private static void waitUntil(BooleanSupplier condition, Duration timeout)
+            throws InterruptedException {
+        long deadlineMs = System.currentTimeMillis() + timeout.toMillis();
+        while (!condition.getAsBoolean()) {
+            long remaining = deadlineMs - System.currentTimeMillis();
+            if (remaining <= 0) {
+                throw new AssertionError("Condition not met within " + timeout);
+            }
+            Thread.sleep(Math.min(10, remaining));
+        }
+    }
 
     private static Uri createUri() {
         return BmqBroker.Domains.Priority.generateQueueUri();
@@ -464,7 +477,7 @@ public class BrokerSessionIT {
      * </ul>
      */
     @Test
-    void pushMessageTest() throws IOException {
+    void pushMessageTest() throws IOException, InterruptedException {
         logger.info("#TEST_BEGIN BrokerSessionIT pushMessageTest");
 
         BmqBrokerSimulator server = new BmqBrokerSimulator(Mode.BMQ_AUTO_MODE);
@@ -497,6 +510,9 @@ public class BrokerSessionIT {
             verifyConfigureRequest(++reqId, server.nextClientRequest());
 
             server.writePushRequest(1);
+
+            // Wait for the push event to be received before closing
+            waitUntil(() -> !events.isEmpty(), Duration.ofSeconds(3));
 
             assertEquals(CloseQueueResult.SUCCESS, queue.close(TEST_REQUEST_TIMEOUT));
             assertEquals(QueueState.e_CLOSED, queue.getState());


### PR DESCRIPTION
Wait for push event before closing a queue.

Fix the following flaky test:

```
Error:  Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 4.013 s <<< FAILURE! - in com.bloomberg.bmq.it.BrokerSessionIT
Error:  com.bloomberg.bmq.it.BrokerSessionIT.pushMessageTest  Time elapsed: 4.013 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <1> but was: <0>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:150)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:145)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:531)
	at com.bloomberg.bmq.it.BrokerSessionIT.pushMessageTest(BrokerSessionIT.java:506)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at java.util.ArrayList.forEach(ArrayList.java:1259)
	at java.util.ArrayList.forEach(ArrayList.java:1259)
[INFO] Running com.bloomberg.bmq.it.BrokerSessionIT
Error:  Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 4.01 s <<< FAILURE! - in com.bloomberg.bmq.it.BrokerSessionIT
Error:  com.bloomberg.bmq.it.BrokerSessionIT.pushMessageTest  Time elapsed: 4.01 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <1> but was: <0>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:150)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:145)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:531)
	at com.bloomberg.bmq.it.BrokerSessionIT.pushMessageTest(BrokerSessionIT.java:506)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at java.util.ArrayList.forEach(ArrayList.java:1259)
	at java.util.ArrayList.forEach(ArrayList.java:1259)
[INFO] Running com.bloomberg.bmq.it.BrokerSessionIT
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.011 s - in com.bloomberg.bmq.it.BrokerSessionIT
[INFO] 
[INFO] Results:
[INFO] 
Warning:  Flakes: 
Warning:  com.bloomberg.bmq.it.BrokerSessionIT.pushMessageTest
Error:    Run 1: BrokerSessionIT.pushMessageTest:506 expected: <1> but was: <0>
Error:    Run 2: BrokerSessionIT.pushMessageTest:506 expected: <1> but was: <0>
Error:    Run 3: BrokerSessionIT.pushMessageTest:506 expected: <1> but was: <0>
```