### PR TITLE
Fix[FSM]: do not reconnect after stop

### DIFF
--- a/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/BrokerConnectionFSMImpl.java
+++ b/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/BrokerConnectionFSMImpl.java
@@ -125,7 +125,7 @@ public class BrokerConnectionFSMImpl implements BrokerConnectionFSM {
             4,  5,  4,  4,  4,  4,  4,  0,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,
         },
         /* s5 DISCONNECTING_BROKER */ {
-            5,  5,  5,  5,  5,  5,  5,  0,  5,  5,  5,  5,  5,  6,  6,  6,  5,  5,  5,  5,
+            5,  5,  5,  5,  5,  5,  5,  6,  5,  5,  5,  5,  5,  6,  6,  6,  5,  5,  5,  5,
         },
         /* s6 DISCONNECTING_CHANNEL */ {
             6,  6,  6,  6,  6,  6,  6,  0,  6,  6,  6,  7,  7,  6,  6,  6,  6,  6,  6,  6,

--- a/bmq-sdk/src/test/java/com/bloomberg/bmq/impl/intf/BrokerConnectionFSMTest.java
+++ b/bmq-sdk/src/test/java/com/bloomberg/bmq/impl/intf/BrokerConnectionFSMTest.java
@@ -95,9 +95,7 @@ public class BrokerConnectionFSMTest {
         for (Inputs i : Inputs.values()) {
             States newState = getState(initState, i);
             switch (i) {
-                case CHANNEL_STATUS_DOWN:
-                    assertEquals(States.CONNECTION_LOST, newState);
-                    break;
+                case CHANNEL_STATUS_DOWN: // fallthrough
                 case DISCONNECT_BROKER_RESPONSE: // fallthrough
                 case DISCONNECT_BROKER_TIMEOUT: // fallthrough
                 case DISCONNECT_BROKER_FAILURE:

--- a/bmq-sdk/src/test/java/com/bloomberg/bmq/it/BrokerSessionIT.java
+++ b/bmq-sdk/src/test/java/com/bloomberg/bmq/it/BrokerSessionIT.java
@@ -352,6 +352,92 @@ public class BrokerSessionIT {
     }
 
     /**
+     * Once a session has been asked to stop, it must stay stopped even if the broker connection is
+     * lost during the disconnect handshake.
+     *
+     * <p>Scenario:
+     *
+     * <ul>
+     *   <li>Bring the session up against a MANUAL-mode simulator.
+     *   <li>Call {@code stop()} (on a background thread since it blocks). It sends a Disconnect
+     *       request and waits for the DisconnectResponse.
+     *   <li>The broker connection is lost (channel dropped) right after it received the Disconnect,
+     *       then a broker becomes available again on the same port.
+     * </ul>
+     *
+     * <p>Expected behavior: after {@code stop()} has been requested the session stays down --
+     * {@code isStarted()} remains {@code false} and the session does not reconnect to the broker
+     * that came back up.
+     */
+    @Test
+    void sessionMustNotReconnectAfterStop() throws Exception {
+        logger.info("#TEST_BEGIN BrokerSessionIT sessionMustNotReconnectAfterStop");
+
+        BmqBrokerSimulator server = new BmqBrokerSimulator(Mode.BMQ_MANUAL_MODE);
+        server.start();
+        final int port = server.getPort();
+
+        SessionOptions sessionOptions =
+                SessionOptions.builder().setBrokerUri(server.getURI()).build();
+        TcpConnectionFactory connectionFactory = new NettyTcpConnectionFactory();
+        ScheduledExecutorService service = Executors.newSingleThreadScheduledExecutor();
+        LinkedList<Event> events = new LinkedList<>();
+        BrokerSession session =
+                BrokerSession.createInstance(
+                        sessionOptions, connectionFactory, service, events::push);
+
+        BmqBrokerSimulator restarted = null;
+        // stop() is issued asynchronously because it blocks; the assertion is on the
+        // session state, not on stop()'s return code.
+        CompletableFuture<GenericResult> stopResult = null;
+        try {
+            server.pushItem(StatusCategory.E_SUCCESS); // negotiation OK -> session up
+            assertEquals(GenericResult.SUCCESS, session.start(Duration.ofSeconds(5)));
+            assertTrue(session.isStarted());
+
+            // Ask the session to stop. We deliberately push NO response for the
+            // Disconnect, so the client sends it and then waits for a response.
+            stopResult = CompletableFuture.supplyAsync(() -> session.stop(Duration.ofSeconds(3)));
+
+            // Confirm the Disconnect reached the broker, then drop the connection.
+            ControlMessageChoice req = server.nextClientRequest();
+            assertNotNull(req, "expected a Disconnect request from the client");
+            assertTrue(req.isDisconnectValue());
+            server.stop(); // connection lost while the client awaits DisconnectResponse
+
+            // Make a broker available again on the same port.
+            restarted = new BmqBrokerSimulator(port, Mode.BMQ_MANUAL_MODE);
+            restarted.pushItem(StatusCategory.E_SUCCESS); // in case of re-negotiation
+            restarted.start();
+
+            // Wait well past the reconnect retry interval (5s default).
+            TestTools.sleepForSeconds(8);
+
+            // A session that was asked to stop stays down.
+            assertFalse(
+                    session.isStarted(),
+                    "session that was asked to stop must not reconnect to the broker");
+        } catch (Exception e) {
+            logger.error("Exception: ", e);
+            throw e;
+        } finally {
+            if (stopResult != null) {
+                try {
+                    stopResult.get(10, TimeUnit.SECONDS);
+                } catch (Exception ignored) {
+                    // best-effort: we do not rely on stop()'s return code here
+                }
+            }
+            session.linger();
+            server.stop();
+            if (restarted != null) {
+                restarted.stop();
+            }
+            logger.info("#TEST_END BrokerSessionIT sessionMustNotReconnectAfterStop");
+        }
+    }
+
+    /**
      * Test for synchronous operations under queue (open-configure-close);
      *
      * <ul>


### PR DESCRIPTION
# Problem

Once a session has been asked to `stop()`, it must stay stopped. But if the broker connection is lost during the disconnect handshake (after the SDK sends `Disconnect` but before it receives the `DisconnectResponse`), the session reconnects instead of stopping.

# Root cause

In the `BrokerConnection` FSM, the `DISCONNECTING_BROKER` state routed `CHANNEL_STATUS_DOWN` (e7) to `CONNECTION_LOST` - the reconnect state. Since a stop was already in progress, the channel loss should have proceeded toward shutdown, but instead the FSM scheduled a reconnect, and when a broker came back on the same port the session negotiated a fresh connection and came back up.

The bug sequence:

<img width="900" height="700" alt="stop_bug" src="https://github.com/user-attachments/assets/276a5036-13fa-4c0a-9687-127de2672f75" />

# Fix

From `DISCONNECTING_BROKER`, route `CHANNEL_STATUS_DOWN` to the next stage `DISCONNECTING_CHANNEL` (the same target as the normal `DISCONNECT_BROKER_RESPONSE`/`TIMEOUT`/`FAILURE` path), not to `CONNECTION_LOST`. Entering `DISCONNECTING_CHANNEL` calls `connection.disconnect(...)`, which flips the Netty channel to `DISCONNECTING` and cancels the pending reconnect, so the FSM lands in `STOPPED`.

One change in the transition table plus the corresponding FSM unit-test expectation.

# Test

The test fails on main and passes in this PR:

```
[ERROR] com.bloomberg.bmq.it.BrokerSessionIT.sessionMustNotReconnectAfterStop
[ERROR]   Run 1: BrokerSessionIT.sessionMustNotReconnectAfterStop:417 session that was asked to stop must not reconnect to the broker ==> expected: <false> but was: <true>
[ERROR]   Run 2: BrokerSessionIT.sessionMustNotReconnectAfterStop:417 session that was asked to stop must not reconnect to the broker ==> expected: <false> but was: <true>
[ERROR]   Run 3: BrokerSessionIT.sessionMustNotReconnectAfterStop:417 session that was asked to stop must not reconnect to the broker ==> expected: <false> but was: <true>
[ERROR]   Run 4: BrokerSessionIT.sessionMustNotReconnectAfterStop:417 session that was asked to stop must not reconnect to the broker ==> expected: <false> but was: <true>
```
