### PR TITLE
Fix[QueueId]: incorrect operator order in hash

### DIFF
--- a/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/QueueId.java
+++ b/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/QueueId.java
@@ -55,7 +55,7 @@ public final class QueueId {
     @Override
     public int hashCode() {
         long l = id;
-        l = l << 32 + subId;
+        l = (l << 32) + subId;
         Long hashed = l;
         return hashed.hashCode();
     }


### PR DESCRIPTION
Low entropy of hash function due to a wrong order of operations