### PR TITLE
Fix[Options]: correct handling of packed options

### DIFF
--- a/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/infr/proto/Options.java
+++ b/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/infr/proto/Options.java
@@ -43,6 +43,12 @@ public class Options {
         while (size > 0) {
             OptionHeader header = new OptionHeader();
             header.streamIn(bbis);
+
+            int totalSize =
+                    header.packed()
+                            ? OptionHeader.HEADER_SIZE
+                            : header.words() * Protocol.WORD_SIZE;
+
             switch (header.type()) {
                 case SUB_QUEUE_INFOS:
                     if (subQueueInfosOption == null) {
@@ -51,32 +57,29 @@ public class Options {
                         logger.debug("New options: {}", subQueueInfosOption);
                     } else {
                         logger.warn("Multiple SubQueueInfos option: {}", header.type());
-
-                        int numSkip =
-                                header.packed()
-                                        ? 0
-                                        : header.words() * Protocol.WORD_SIZE
-                                                - OptionHeader.HEADER_SIZE;
-
-                        bbis.skip(numSkip);
+                        bbis.skip(totalSize - OptionHeader.HEADER_SIZE);
                     }
                     break;
                 case SUB_QUEUE_IDS_OLD:
+                    // Only SUB_QUEUE_INFOS options may be packed.
+                    assert !header.packed();
                     if (subQueueIdsOption == null) {
                         subQueueIdsOption = new SubQueueIdsOption(header);
                         subQueueIdsOption.streamIn(bbis);
                         logger.debug("Old options: {}", subQueueIdsOption);
                     } else {
                         logger.warn("Multiple SubQueueIds option: {}", header.type());
-                        bbis.skip(header.words() * Protocol.WORD_SIZE - OptionHeader.HEADER_SIZE);
+                        bbis.skip(totalSize - OptionHeader.HEADER_SIZE);
                     }
                     break;
                 default:
+                    // Only SUB_QUEUE_INFOS options may be packed.
+                    assert !header.packed();
                     logger.warn("Unsupported option type: {}", header.type());
-                    bbis.skip(header.words() * Protocol.WORD_SIZE - OptionHeader.HEADER_SIZE);
+                    bbis.skip(totalSize - OptionHeader.HEADER_SIZE);
                     break;
             }
-            size -= header.words() * Protocol.WORD_SIZE;
+            size -= totalSize;
         }
 
         if (subQueueIdsOption != null && subQueueInfosOption != null) {

--- a/bmq-sdk/src/test/java/com/bloomberg/bmq/impl/infr/proto/OptionsTest.java
+++ b/bmq-sdk/src/test/java/com/bloomberg/bmq/impl/infr/proto/OptionsTest.java
@@ -97,6 +97,44 @@ class OptionsTest {
     }
 
     @Test
+    void testStreamInPackedInfosThenIds() throws IOException {
+        // A *packed* SUB_QUEUE_INFOS option occupies exactly one word (4 bytes): the
+        // header only, with no option content. Its 'words' field is reinterpreted as
+        // the RDA counter, so 'size' must be decremented by HEADER_SIZE, not by
+        // words()*WORD_SIZE. If a second option follows, an incorrect decrement causes
+        // the loop to exit early and the trailing option to be misread/dropped.
+        ByteBuffer bb =
+                ByteBuffer.wrap(
+                        new byte[] {
+                            // Packed Infos: type=SUB_QUEUE_INFOS(3), packed=1,
+                            // words field reused as RDA counter (5)
+                            0b00001110, 0b00000000, 0b00000000, 0b00000101, // header only
+
+                            // Ids
+                            0b00000100, 0b00000000, 0b00000000, 0b00000010, // header
+                            0b00000000, 0b00000000, 0b00000000, 0b00000111, // subqueue id 7
+                        });
+        ByteBufferInputStream bbis = new ByteBufferInputStream(bb);
+
+        Options options = new Options();
+        options.streamIn(12, bbis);
+
+        logger.info("Options: {}", options);
+
+        assertNotNull(options.subQueueInfosOption());
+        assertArrayEquals(
+                new Integer[] {com.bloomberg.bmq.impl.QueueId.k_DEFAULT_SUBQUEUE_ID},
+                options.subQueueInfosOption().subQueueIds());
+
+        // The option after the packed one must still be parsed.
+        assertNotNull(options.subQueueIdsOption());
+        assertArrayEquals(new Integer[] {7}, options.subQueueIdsOption().subQueueIds());
+
+        // Check that input stream is empty
+        assertEquals(0, bbis.available());
+    }
+
+    @Test
     void testStreamInInfosIds() throws IOException {
         ByteBuffer bb =
                 ByteBuffer.wrap(


### PR DESCRIPTION
# Problem

When parsing options, the loop decremented the remaining size by `header.words() * WORD_SIZE`. For a packed `SUB_QUEUE_INFOS` option, `words()` is reinterpreted as the RDA counter - not a length — while the option occupies exactly one word (the header) on the wire. If another option followed a packed one, size was over-decremented, the loop exited early, and the trailing option bytes were misread as payload -> CRC/parse failure and a dropped message. Latent in the common non-fanout case where the packed option is the only one.

# Fix

Compute the option's actual on-wire size once (totalSize, packed-aware) and use it consistently for the size decrement and all skip paths, so byte accounting can never desync regardless of the packed flag.

# Test

Added `OptionsTest.testStreamInPackedInfosThenIds`: a packed `SUB_QUEUE_INFOS` option followed by a `SUB_QUEUE_IDS_OLD` option. Fails on the old code (trailing option dropped, stream left non-empty); passes with the fix.