### PR TITLE
Fix[InboundEventBuffer]: make `reportLwm` volatile

### DIFF
--- a/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/InboundEventBuffer.java
+++ b/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/InboundEventBuffer.java
@@ -36,7 +36,9 @@ public final class InboundEventBuffer {
     private final SessionOptions.InboundEventBufferWaterMark watermarks;
     private final EventQueueStats eventQueueStats;
 
-    private boolean reportLwm = false;
+    // volatile: written by put (scheduler thread) and poll (worker thread),
+    // so both must see each other's latest value.
+    private volatile boolean reportLwm = false;
 
     public InboundEventBuffer(
             SessionOptions.InboundEventBufferWaterMark wms, EventQueueStats eventQueueStats) {


### PR DESCRIPTION
`reportLwm` is a check-then-act guard for slow-consumer high/low watermark events. It's written by `put()` on the scheduler thread and by `poll()` on the worker thread, but was a plain (non-volatile) field. Without a happens-before edge, a stale read can permanently strand slow-consumer notifications — the buffer may never emit `SLOWCONSUMER_NORMAL` after an `HWM`, or never re-emit `HWM`.

Marked the field volatile so both threads see each other's latest value.