### PR TITLE
Fix[BrokerConnectionFSMImpl]: guard start-only errors

### DIFF
--- a/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/BrokerConnectionFSMImpl.java
+++ b/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/BrokerConnectionFSMImpl.java
@@ -454,13 +454,17 @@ public class BrokerConnectionFSMImpl implements BrokerConnectionFSM {
         @Override
         public void onAuthenticationFailed() {
             logger.debug("onAuthenticationFailed: {}", this);
-            startErrorStatus = StartStatus.AUTHENTICATION_FAILURE;
+            if (!isOnceStarted) {
+                startErrorStatus = StartStatus.AUTHENTICATION_FAILURE;
+            }
         }
 
         @Override
         public void onAuthenticationTimeout() {
             logger.debug("onAuthenticationTimeout: {}", this);
-            startErrorStatus = StartStatus.AUTHENTICATION_FAILURE;
+            if (!isOnceStarted) {
+                startErrorStatus = StartStatus.AUTHENTICATION_FAILURE;
+            }
         }
 
         @Override
@@ -493,13 +497,17 @@ public class BrokerConnectionFSMImpl implements BrokerConnectionFSM {
         @Override
         public void onNegotiationFailed() {
             logger.debug("onNegotiationFailed: {}", this);
-            startErrorStatus = StartStatus.NEGOTIATION_FAILURE;
+            if (!isOnceStarted) {
+                startErrorStatus = StartStatus.NEGOTIATION_FAILURE;
+            }
         }
 
         @Override
         public void onNegotiationTimeout() {
             logger.debug("onNegotiationTimeout: {}", this);
-            startErrorStatus = StartStatus.NEGOTIATION_FAILURE;
+            if (!isOnceStarted) {
+                startErrorStatus = StartStatus.NEGOTIATION_FAILURE;
+            }
         }
 
         @Override


### PR DESCRIPTION
`Authenticating` (`onAuthenticationFailed`/`onAuthenticationTimeout`) and `Negotiating`'s (`onNegotiationFailed`/`onNegotiationTimeout`) set `startErrorStatus` unconditionally, unlike every sibling handler which guards with `if (!isOnceStarted)`.

Impact: after a successful start (`isOnceStarted=true`), a channel drop triggers reconnect (`CONNECTION_LOST` -> `AUTHENTICATING` -> `NEGOTIATING`). If re-negotiation fails/times out, `startErrorStatus` gets set and `Stopped.onEnter` fires `reportStartStatus(...)` — a bogus start-error delivered long after `start()` already returned `SUCCESS`. The FSM is left `STOPPED` while `BrokerSession` still thinks it's up.

Fix: guard all four assignments with `if (!isOnceStarted)`, mirroring `ConnectionLost` and the `onStopRequest` handlers.

No behavior change on the actual start path (failures there have `isOnceStarted=false`).

<img width="960" height="820" alt="fsm_bug3" src="https://github.com/user-attachments/assets/b0f762ad-ba39-4875-8358-5f00ccffedf9" />
