### PR TITLE
Fix[QueueManager]: prevent half-registered queues

### DIFF
--- a/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/QueueManager.java
+++ b/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/QueueManager.java
@@ -101,6 +101,15 @@ public class QueueManager {
             if (queueInfo == null) {
                 queueInfo = new QueueInfo(queue.getQueueId());
             }
+
+            // Check for a duplicate subQueue before mutating any state, so a
+            // rejected insert leaves the maps untouched (no partial registration).
+            Map<String, Integer> subQueueIdsMap = queueInfo.getSubQueueIdsMap();
+            Integer subQueueId = subQueueIdsMap.get(uri.id());
+            if (subQueueId != null) {
+                return false;
+            }
+
             uriMap.put(uriString, queueInfo);
             QueueId queueId = queue.getFullQueueId();
             keyQueueIdMap.put(queueId, queue);
@@ -109,11 +118,6 @@ public class QueueManager {
                 subscriptionIdMap.put(sId, queue);
             }
 
-            Map<String, Integer> subQueueIdsMap = queueInfo.getSubQueueIdsMap();
-            Integer subQueueId = subQueueIdsMap.get(uri.id());
-            if (subQueueId != null) {
-                return false;
-            }
             subQueueIdsMap.put(uri.id(), queue.getSubQueueId());
         }
         return true;


### PR DESCRIPTION
# Problem

`insert()` wrote to `uriMap`, `keyQueueIdMap`, and `subscriptionIdMap` before the `appId`-duplicate guard that returns false. On failure these writes were never rolled back. Opening the same fanout `appId` twice (same URI, different subIds) passes the earlier preconditions but makes insert return false after already mutating the maps — in debug builds assert res throws on the scheduler thread and the open future never completes (blocks to timeout); in prod the second queue is leaked in the maps.

# Fix

Move the duplicate-`subQueue` check ahead of all map mutations, so a rejected insert leaves state untouched.

Behavior preserved: the success path performs the same writes in the same order; `queueInfo` is either freshly created (empty map, guard never trips) or the existing `uriMap` entry (re-put is a no-op).