### PR TITLE
Fix[QueueManager]: synchronize generateNextQueueId on lock

### DIFF
--- a/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/QueueManager.java
+++ b/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/QueueManager.java
@@ -319,20 +319,23 @@ public class QueueManager {
      * @return QueueId object
      */
     public QueueId generateNextQueueId(Uri uri) {
-        // TODO: implement complete logic
-        QueueInfo qInfo = uriMap.get(uri.canonical());
-        int subQueueId = 0;
-        if (qInfo != null) {
-            if (!uri.id().isEmpty()) {
-                subQueueId = qInfo.getNextSubQueueId();
+        // TODO: IDs are allocated monotonically and never recycled; closed/expired
+        // queue IDs are not reused, and generation does not consult expiredQueueMap.
+        synchronized (lock) {
+            QueueInfo qInfo = uriMap.get(uri.canonical());
+            int subQueueId = 0;
+            if (qInfo != null) {
+                if (!uri.id().isEmpty()) {
+                    subQueueId = qInfo.getNextSubQueueId();
+                }
+                return QueueId.createInstance(qInfo.getQueueId(), subQueueId);
+            } else {
+                if (!uri.id().isEmpty()) {
+                    subQueueId = QueueInfo.INITIAL_CONSUMER_SUBQUEUE_ID;
+                }
+                int queueId = nextQueueId.getAndIncrement();
+                return QueueId.createInstance(queueId, subQueueId);
             }
-            return QueueId.createInstance(qInfo.getQueueId(), subQueueId);
-        } else {
-            if (!uri.id().isEmpty()) {
-                subQueueId = QueueInfo.INITIAL_CONSUMER_SUBQUEUE_ID;
-            }
-            int queueId = nextQueueId.getAndIncrement();
-            return QueueId.createInstance(queueId, subQueueId);
         }
     }
 


### PR DESCRIPTION
`generateNextQueueId()` was the only method in `QueueManager` `@ThreadSafe` class that read/mutated shared state outside lock. It read `uriMap`, bumped the per-URI `subQueueId` counter (`getNextSubQueueId()`), and read/incremented `nextQueueId` unsynchronized while user threads accessed the same maps under lock — a visibility/consistency race.

Change: wrap the whole method body in `synchronized (lock)`, matching every other method here.

Also replaced the stale `// TODO`
