### PR TITLE
Fix: CloseQueueStrategy leaks queue on failed close-request write

### DIFF
--- a/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/CloseQueueStrategy.java
+++ b/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/CloseQueueStrategy.java
@@ -261,7 +261,17 @@ public class CloseQueueStrategy extends QueueControlStrategy<CloseQueueCode> {
 
         if (genericResult.isFailure()) {
             logger.error("Failed to send closeQueue request. RC={}", genericResult);
-            setQueueState(QueueState.e_CLOSED);
+            if (scenario.isDefault()) {
+                // If no connection the queue now is closed.
+                onFullyClosed();
+                if (genericResult.isNotConnected()) {
+                    genericResult = GenericResult.SUCCESS;
+                }
+            } else {
+                // The late scenarios have already removed the queue from the
+                // active maps, so just mark it closed (mirrors onCloseResponse()).
+                setQueueState(QueueState.e_CLOSED);
+            }
 
             resultHook(genericResult);
         }

--- a/bmq-sdk/src/test/java/com/bloomberg/bmq/impl/BrokerSessionTest.java
+++ b/bmq-sdk/src/test/java/com/bloomberg/bmq/impl/BrokerSessionTest.java
@@ -1254,7 +1254,9 @@ class BrokerSessionTest {
 
             obj.sendConfigureStreamResponse(configureRequest);
 
-            assertEquals(CloseQueueResult.NOT_CONNECTED, closeFuture.get(FUTURE_TIMEOUT));
+            // With no connection the queue is considered closed, so close
+            // reports success.
+            assertEquals(CloseQueueResult.SUCCESS, closeFuture.get(FUTURE_TIMEOUT));
 
             // Check close request
             obj.verifyCloseQueueRequest(true);
@@ -1266,21 +1268,16 @@ class BrokerSessionTest {
 
             // Check event
             obj.verifyQueueControlEvent(
-                    QueueControlEvent.Type.e_QUEUE_CLOSE_RESULT, CloseQueueResult.NOT_CONNECTED);
+                    QueueControlEvent.Type.e_QUEUE_CLOSE_RESULT, CloseQueueResult.SUCCESS);
 
             assertEquals(QueueState.e_CLOSED, queue.getState());
 
             // Open the queue
             obj.connection().resetWriteStatus(); // SUCCESS
 
-            // Due to the bug, queue is not closed fully, so we cannot reopen it
-            logger.info("[BUG] Current queue cannot be reopened");
-            assertEquals(
-                    OpenQueueResult.QUEUE_ID_NOT_UNIQUE,
-                    queue.open(queueOptions, SEQUENCE_TIMEOUT));
-
-            // Create and open another queue
-            queue = obj.createQueue(createUri(), flags);
+            // The queue is fully closed and no longer registered in the active
+            // queue map, so the same queue can be reopened.
+            assertNull(obj.queueManager().findByQueueId(queue.getFullQueueId()));
 
             obj.openQueue(queue, queueOptions);
 


### PR DESCRIPTION
# Problem

In `handleConfigureStatus`, after a successful configure response, the strategy sends the close-queue request. If that write fails, the queue was marked `e_CLOSED` but never removed from the active queue map (`keyQueueIdMap`), leaving a stuck entry. The URI could not be reopened afterwards.

# Fix

On close-request write failure in the default scenario, call `onFullyClosed()` to remove the queue from the active maps (mirroring the success path in `onCloseResponse`). Late scenarios, where the queue is already removed, just mark it `e_CLOSED`.
