### PR TITLE
Fix[publish.yaml]: check out live main tip for release push

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,6 +11,9 @@ jobs:
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: main
+          fetch-depth: 0
       - uses: actions/setup-java@v3
         with:
           distribution: temurin


### PR DESCRIPTION
release:prepare pushes the version-bump commits to main. actions/checkout@v3 pins to the run's dispatch SHA, so re-running an older dispatch (or a run whose base has advanced) stacks the release commits on a stale base and the push is rejected non-fast-forward: "! [rejected] main -> main (fetch first)".

Pin the checkout to the main branch with full history so release:prepare commits and pushes against the current tip.
