### PR TITLE
Fix[publish.yaml]: use mvn deploy instead of maven-release-plugin

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,14 +6,9 @@ jobs:
   publish:
     name: 'Publish'
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: main
-          fetch-depth: 0
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
@@ -26,13 +21,8 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_KEY }}
           gpg-passphrase: GPG_KEY_PASSPHRASE
 
-      - name: 'Set up GitHub credentials'
-        run: |
-          git config --global user.email "opensource@bloomberg.net"
-          git config --global user.name "Bloomberg Open Source"
-
-      - name: 'Publish snapshot to OSSRH'
-        run: mvn --batch-mode -Possrh -Darguments="-Dmaven.test.skip=true -Dspotbugs.skip=true -Dgpg.keyname=${{ secrets.GPG_KEY_ID }} -Dgpg.passphrase=${{ secrets.GPG_KEY_PASSPHRASE }} -Dusername=${{ secrets.GITHUB_TOKEN }}" release:prepare release:perform
+      - name: 'Publish to OSSRH'
+        run: mvn --batch-mode -Possrh -Dmaven.deploy.skip=false -Dmaven.test.skip=true -Dspotbugs.skip=true -Dgpg.keyname=${{ secrets.GPG_KEY_ID }} -Dgpg.passphrase=${{ secrets.GPG_KEY_PASSPHRASE }} deploy
         env:
           GPG_KEY_PASSPHRASE: ${{ secrets.GPG_KEY_PASSPHRASE }}
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}


### PR DESCRIPTION
Replace release:prepare/release:perform with a plain mvn deploy, which uploads the artifacts to OSSRH without any git operations. 