### PR TITLE
Publish only bmq-sdk to Maven Central; add publish dry-run

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,6 +1,12 @@
 name: 'Publish to Maven Central'
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Build & upload the bundle as a CI artifact WITHOUT publishing to Maven Central'
+        type: boolean
+        default: false
 
 jobs:
   publish:
@@ -23,8 +29,22 @@ jobs:
           gpg-passphrase: GPG_KEY_PASSPHRASE
 
       - name: 'Publish to Maven Central'
-        run: mvn --batch-mode -Possrh -Dmaven.test.skip=true -Dspotbugs.skip=true -Dgpg.keyname=${{ secrets.GPG_KEY_ID }} -Dgpg.passphrase=${{ secrets.GPG_KEY_PASSPHRASE }} deploy
+        run: mvn --batch-mode -Possrh -Dcentral.skipPublishing=${{ inputs.dry_run }} -Dmaven.test.skip=true -Dspotbugs.skip=true -Dgpg.keyname=${{ secrets.GPG_KEY_ID }} -Dgpg.passphrase=${{ secrets.GPG_KEY_PASSPHRASE }} deploy
         env:
           GPG_KEY_PASSPHRASE: ${{ secrets.GPG_KEY_PASSPHRASE }}
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+
+      # Dry run only: surface what WOULD be published so the bundle can be verified
+      # (e.g. that bmq-examples and the aggregator POM are excluded) before a real release.
+      - name: 'Inspect bundle (dry run)'
+        if: ${{ inputs.dry_run }}
+        run: find . -name central-bundle.zip -exec unzip -l {} \;
+
+      - name: 'Upload bundle (dry run)'
+        if: ${{ inputs.dry_run }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: central-bundle
+          path: '**/central-bundle.zip'
+          if-no-files-found: error

--- a/bmq-examples/pom.xml
+++ b/bmq-examples/pom.xml
@@ -18,7 +18,7 @@ limitations under the License. -->
   <parent>
     <groupId>com.bloomberg.bmq</groupId>
     <artifactId>bmq-sdk-java</artifactId>
-    <version>0.0.17</version>
+    <version>0.0.18</version>
   </parent>
 
   <groupId>com.bloomberg.bmq</groupId>
@@ -121,16 +121,4 @@ limitations under the License. -->
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <!-- Example code is not published to Maven Central. The parent's ossrh profile
-         un-skips deploy for a Central Portal publish; re-skip it here so this module
-         is excluded from the bundle. -->
-    <profile>
-      <id>ossrh</id>
-      <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/bmq-sdk/pom.xml
+++ b/bmq-sdk/pom.xml
@@ -18,7 +18,7 @@ limitations under the License. -->
   <parent>
     <groupId>com.bloomberg.bmq</groupId>
     <artifactId>bmq-sdk-java</artifactId>
-    <version>0.0.17</version>
+    <version>0.0.18</version>
   </parent>
   <artifactId>bmq-sdk</artifactId>
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@ limitations under the License. -->
 
   <groupId>com.bloomberg.bmq</groupId>
   <artifactId>bmq-sdk-java</artifactId>
-  <version>0.0.17</version>
+  <version>0.0.18</version>
   <packaging>pom</packaging>
 
   <name>BlazingMQ Java SDK Bundle</name>
@@ -568,10 +568,10 @@ limitations under the License. -->
     <profile>
       <id>ossrh</id>
       <properties>
-        <!-- Un-skip deploy during a Central Portal publish so the parent POM and
-             bmq-sdk are included in the bundle. bmq-examples re-skips itself via
-             its own ossrh profile so example code is not published. -->
-        <maven.deploy.skip>false</maven.deploy.skip>
+        <!-- Dry-run toggle: pass -Dcentral.skipPublishing=true to build the signed
+             bundle WITHOUT uploading/publishing, so its contents can be inspected
+             in CI before a real release. Defaults to a real publish. -->
+        <central.skipPublishing>false</central.skipPublishing>
       </properties>
       <build>
         <plugins>
@@ -639,6 +639,13 @@ limitations under the License. -->
               <publishingServerId>central</publishingServerId>
               <autoPublish>true</autoPublish>
               <waitUntil>published</waitUntil>
+              <skipPublishing>${central.skipPublishing}</skipPublishing>
+              <!-- Publish only the bmq-sdk library: exclude the aggregator POM and
+                   the examples module (matched by artifactId) from the bundle. -->
+              <excludeArtifacts>
+                <excludeArtifact>bmq-sdk-java</excludeArtifact>
+                <excludeArtifact>bmq-examples</excludeArtifact>
+              </excludeArtifacts>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
Exclude the aggregator POM (bmq-sdk-java) and the examples module (bmq-examples), so only the bmq-sdk library is released.  Add a dry_run toggle & bump version to 0.0.18.

