### PR TITLE
 Fix[CI] Add permissions to sanity-check.yaml

### DIFF
--- a/.github/workflows/sanity-check.yaml
+++ b/.github/workflows/sanity-check.yaml
@@ -1,4 +1,6 @@
 name: Sanity check
+permissions:
+  contents: read
 on:
   pull_request:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/bloomberg/blazingmq-sdk-java/security/code-scanning/3](https://github.com/bloomberg/blazingmq-sdk-java/security/code-scanning/3)

Add an explicit `permissions` block to `.github/workflows/sanity-check.yaml` so `GITHUB_TOKEN` is constrained regardless of repo/org defaults.  
Best single fix without changing functionality: set workflow-level permissions to read-only for repository contents, which is typically sufficient for pull-request metadata/commit inspection workflows.

**Change to make:**
- In `.github/workflows/sanity-check.yaml`, insert at workflow root (after `name` and before `on`):
  - `permissions:`
  - `  contents: read`

No imports, methods, or dependencies are needed (YAML workflow-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
