### PR TITLE
CI: Update maven publish to use 'release' environment

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,13 +2,20 @@ name: 'Publish to Maven Central'
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: 'Publish'
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    environment: release
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
@@ -23,8 +30,9 @@ jobs:
           gpg-passphrase: GPG_KEY_PASSPHRASE
 
       - name: 'Publish to Maven Central'
-        run: mvn --batch-mode -Possrh -Dmaven.test.skip=true -Dspotbugs.skip=true -Dgpg.keyname=${{ secrets.GPG_KEY_ID }} -Dgpg.passphrase=${{ secrets.GPG_KEY_PASSPHRASE }} deploy
+        run: mvn --batch-mode -Possrh -Dmaven.test.skip=true -Dspotbugs.skip=true -Dgpg.keyname="$GPG_KEY_ID" deploy
         env:
+          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
           GPG_KEY_PASSPHRASE: ${{ secrets.GPG_KEY_PASSPHRASE }}
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}


### PR DESCRIPTION
Minor cleanup of publish workflow and first phase of migrating to environment-based secrets instead of repo-based secrets.