### PR TITLE
Misc: Adopt org-wide dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,5 +2,19 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "actions/*"
+          - "github/*"
+      github-owned-actions:
+        patterns:
+          - "actions/*"
+          - "github/*"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
+


### PR DESCRIPTION
Using the Bloomberg org's [dependabot template](https://github.com/bloomberg/.github/blob/6e6478c5f719f8ac2251558635f700dd5c0f128e/.github/dependabot.yml).