### PR TITLE
CI: Add scorecard.yaml for OpenSSF Scorecard

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,0 +1,30 @@
+---
+name: scorecard
+
+on:
+  push:
+    branches:
+      # Run on pushes to default branch
+      - main
+  schedule:
+    # Run weekly on Saturdays
+    - cron: "30 1 * * 6"
+  # Run when branch protection rules change
+  branch_protection_rule:
+  # Run the workflow manually
+  workflow_dispatch:
+
+# Declare default permissions as read-only
+permissions: read-all
+
+jobs:
+  run-scorecard:
+    # Call reusable workflow file
+    uses: bloomberg/.github/.github/workflows/_scorecard.yml@main
+    permissions:
+      id-token: write
+      security-events: write
+    secrets: inherit
+    with:
+      # Publish results of Scorecard analysis
+      publish-results: true


### PR DESCRIPTION
Run Bloomberg's reusable OpenSSF Scorecard workflow weekly on Saturdays.

Copied from the Bloomberg [repo template](https://github.com/bloomberg/oss-template/blob/9179c76211c9922942c2e82b5acb8a9de2e056e3/.github/workflows/scorecard.yml).