### PR TITLE
Add maven to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,14 @@ updates:
     cooldown:
       default-days: 7
 
+  - package-ecosystem: "maven"
+    directory: "/"
+    groups:
+      maven:
+        patterns:
+          - "*"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+


### PR DESCRIPTION
Match the 7-day cooldown for github actions.