### PR TITLE
Build: update netty version, fix deprecated component usage

### DIFF
--- a/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/infr/net/NettyTcpConnection.java
+++ b/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/infr/net/NettyTcpConnection.java
@@ -32,8 +32,9 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.WriteBufferWaterMark;
-import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.util.concurrent.Future;
@@ -326,7 +327,7 @@ public final class NettyTcpConnection extends ChannelInboundHandlerAdapter
         synchronized (lock) {
             this.options = options;
             numRemainingInitialTries = this.options.startNumRetries();
-            eventLoop = new NioEventLoopGroup(NUM_IO_THREADS);
+            eventLoop = new MultiThreadIoEventLoopGroup(NUM_IO_THREADS, NioIoHandler.newFactory());
             readCallback = readCb;
             connectCallback = connectCb;
             clientChannelAdapter.reset();

--- a/bmq-sdk/src/test/java/com/bloomberg/bmq/it/util/BmqBrokerSimulator.java
+++ b/bmq-sdk/src/test/java/com/bloomberg/bmq/it/util/BmqBrokerSimulator.java
@@ -50,7 +50,8 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import java.io.IOException;
@@ -490,7 +491,8 @@ public class BmqBrokerSimulator implements TestTcpServer, Runnable {
     public void run() {
         final int NUM_IO_THREADS = 1;
         final NettyServerHandler handler = new NettyServerHandler();
-        final EventLoopGroup eventLoop = new NioEventLoopGroup(NUM_IO_THREADS);
+        final EventLoopGroup eventLoop =
+                new MultiThreadIoEventLoopGroup(NUM_IO_THREADS, NioIoHandler.newFactory());
 
         try {
             ServerBootstrap b = new ServerBootstrap();

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@ limitations under the License. -->
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.1.79.Final</version>
+        <version>4.2.17.Final</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Fixes the following warning that makes the build fail
```
Warning: [WARNING] /home/runner/work/blazingmq-sdk-java/blazingmq-sdk-java/bmq-sdk/src/main/java/com/bloomberg/bmq/impl/infr/net/NettyTcpConnection.java:[329,29] io.netty.channel.nio.NioEventLoopGroup in io.netty.channel.nio has been deprecated
```